### PR TITLE
hotfix - 이메일 토큰 재전송 로직 수정

### DIFF
--- a/src/main/java/vanille/vocabe/entity/EmailToken.java
+++ b/src/main/java/vanille/vocabe/entity/EmailToken.java
@@ -32,8 +32,8 @@ public class EmailToken {
         return emailToken;
     }
 
-    public void setExpired() {
-        this.expired = true;
+    public void setExpired(boolean flag) {
+        this.expired = flag;
     }
 
     public void refreshEmailToken() {

--- a/src/main/java/vanille/vocabe/service/email/EmailServiceImpl.java
+++ b/src/main/java/vanille/vocabe/service/email/EmailServiceImpl.java
@@ -46,7 +46,7 @@ public class EmailServiceImpl implements EmailService{
             throw new ExpiredTokenException(ErrorCode.EXPIRED_TOKEN);
         }
 
-        emailToken.setExpired();
+        emailToken.setExpired(true);
 
 
         return verifyUser(findUser);

--- a/src/main/java/vanille/vocabe/service/email/EmailTokenServiceImpl.java
+++ b/src/main/java/vanille/vocabe/service/email/EmailTokenServiceImpl.java
@@ -33,6 +33,7 @@ public class EmailTokenServiceImpl implements EmailTokenService {
         if(byEmail.isPresent()) {
             emailToken = byEmail.get();
             emailToken.refreshEmailToken();
+            emailToken.setExpired(false);
         } else {
             emailToken = EmailToken.createEmailToken(email);
             emailTokenRepository.save(emailToken);

--- a/src/test/java/vanille/vocabe/service/email/EmailTokenServiceTest.java
+++ b/src/test/java/vanille/vocabe/service/email/EmailTokenServiceTest.java
@@ -52,6 +52,7 @@ class EmailTokenServiceTest {
         emailTokenService.createEmailToken(email);
         Assertions.assertNotEquals(emailToken.getExpirationDate(), now);
         Assertions.assertNotEquals(emailToken.getToken(), tokenId);
+        Assertions.assertFalse(emailToken.isExpired());
     }
 
 


### PR DESCRIPTION
이메일 토큰을 재전송할 때 expired flag를 false로 바꾸는 로직 추가함.